### PR TITLE
Change default and example values of OCVmin

### DIFF
--- a/Modelica/Electrical/Analog/Batteries.mo
+++ b/Modelica/Electrical/Analog/Batteries.mo
@@ -40,7 +40,7 @@ whoses losses are dissipated to the optional <code>heatPort</code>.
       parameter Boolean useLinearSOCDependency=true
         "Use a linear SOC dependent OCV, otherwise table based";
       parameter Modelica.SIunits.Voltage OCVmax(final min=0) "OCV at SOC = SOCmax";
-      parameter Modelica.SIunits.Voltage OCVmin(final min=0)=0 "OCV at SOC = SOCmin"
+      parameter Modelica.SIunits.Voltage OCVmin(final min=0, start=0) "OCV at SOC = SOCmin"
         annotation(Dialog(enable=useLinearSOCDependency));
       parameter Real SOCmax(final max=1)=1 "Max. state of charge";
       parameter Real SOCmin(final min=0)=0 "Min. state of charge";

--- a/Modelica/Electrical/Analog/Examples/BatteryDischargeCharge.mo
+++ b/Modelica/Electrical/Analog/Examples/BatteryDischargeCharge.mo
@@ -4,6 +4,7 @@ model BatteryDischargeCharge "Discharge and charge idealized battery"
   Modelica.Electrical.Analog.Batteries.BatteryOCV_SOCtable battery(
     OCVmax=12,
     Qnom=36000,
+    OCVmin=10,
     OCV_SOC=[0,0; 0.1,0.9; 1,1],
     Isc=1200,
     useHeatPort=false,


### PR DESCRIPTION
OCVmin = 0 is not a realistic value for an applications. It is thus better to provide only a start value for OCVmin or to omit the default value at all