### PR TITLE
Unify changes of Magnetic.FluxTubes and Magentic.QuasiStatic.FluxTubes

### DIFF
--- a/Modelica/Magnetic/FluxTubes/BaseClasses/Generic.mo
+++ b/Modelica/Magnetic/FluxTubes/BaseClasses/Generic.mo
@@ -1,6 +1,7 @@
 within Modelica.Magnetic.FluxTubes.BaseClasses;
 partial model Generic "Partial Tellinen hysteresis model"
   extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.FluxTubes.Icons.Reluctance;
 
   // Group Fixed Geometry (Cuboid)
   parameter SI.Length l=0.1 "Length in direction of flux" annotation (Dialog(group="Fixed geometry", groupImage=
@@ -14,14 +15,6 @@ partial model Generic "Partial Tellinen hysteresis model"
         Text(
           extent={{-150,50},{150,90}},
           textString="%name",
-          textColor={0,0,255}),
-        Line(points={{-70,0},{-100,0}}, color={255,128,0}),
-        Rectangle(
-          extent={{-70,30},{70,-30}},
-          lineColor={255,128,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Line(points={{70,0},{100,0}}, color={255,128,0})}),
-                                 Documentation(info="<html>
+          textColor={0,0,255})}),Documentation(info="<html>
 </html>"));
 end Generic;

--- a/Modelica/Magnetic/FluxTubes/BaseClasses/Leakage.mo
+++ b/Modelica/Magnetic/FluxTubes/BaseClasses/Leakage.mo
@@ -2,6 +2,7 @@ within Modelica.Magnetic.FluxTubes.BaseClasses;
 partial model Leakage "Base class for leakage flux tubes with position-independent permeance and hence no force generation; mu_r=1"
 
   extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.FluxTubes.Icons.Reluctance;
 
   SI.Reluctance R_m "Magnetic reluctance";
   SI.Permeance G_m "Magnetic permeance";
@@ -13,13 +14,6 @@ equation
   annotation (Icon(coordinateSystem(
       preserveAspectRatio=false,
       extent={{-100,-100},{100,100}}), graphics={
-      Rectangle(
-        extent={{-70,30},{70,-30}},
-        lineColor={255,128,0},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Line(points={{-70,0},{-90,0}}, color={255,128,0}),
-      Line(points={{70,0},{90,0}}, color={255,128,0}),
       Text(
         extent={{-150,50},{150,90}},
         textString="%name",

--- a/Modelica/Magnetic/FluxTubes/Icons/Cuboid.mo
+++ b/Modelica/Magnetic/FluxTubes/Icons/Cuboid.mo
@@ -6,20 +6,20 @@ partial model Cuboid "Icon for cuboid"
           textString="%name",
           textColor={0,0,255}),
         Rectangle(
-          extent={{-60,20},{40,-40}},
+          extent={{-70,20},{50,-40}},
           lineColor={255,128,0},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
         Polygon(
-          points={{-60,20},{-40,40},{60,40},{40,20},{-60,20}},
+          points={{-70,20},{-50,40},{70,40},{50,20},{-70,20}},
           lineColor={255,128,0},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
         Polygon(
-          points={{40,20},{60,40},{60,-20},{40,-40},{40,20}},
+          points={{50,20},{70,40},{70,-20},{50,-40},{50,20}},
           lineColor={255,128,0},
           fillColor={215,215,215},
           fillPattern=FillPattern.Solid),
-        Line(points={{-60,0},{-100,0}}, color={255,128,0}),
-        Line(points={{100,0},{50,0}},   color={255,128,0})}));
+        Line(points={{-70,0},{-100,0}}, color={255,128,0}),
+        Line(points={{100,0},{60,0}},   color={255,128,0})}));
 end Cuboid;

--- a/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/Cuboid.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/Cuboid.mo
@@ -3,6 +3,7 @@ model Cuboid
   "Flux tube with rectangular cross-section; fixed shape; linear or non-linear material characteristics"
 
   extends BaseClasses.FixedShape;
+  extends Modelica.Magnetic.FluxTubes.Icons.Cuboid;
 
   parameter SI.Length l=0.01 "Length in direction of flux" annotation (
       Dialog(group="Fixed geometry", groupImage=
@@ -24,22 +25,5 @@ Please refer to the enclosing sub-package <a href=\"modelica://Modelica.Magnetic
         Text(
           extent={{-150,50},{150,90}},
           textString="%name",
-          textColor={0,0,255}),
-        Rectangle(
-          extent={{-60,20},{40,-40}},
-          lineColor={255,128,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{-60,20},{-40,40},{60,40},{40,20},{-60,20}},
-          lineColor={255,128,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Polygon(
-          points={{40,20},{60,40},{60,-20},{40,-40},{40,20}},
-          lineColor={255,128,0},
-          fillColor={215,215,215},
-          fillPattern=FillPattern.Solid),
-        Line(points={{-60,0},{-100,0}}, color={255,128,0}),
-        Line(points={{90,0},{50,0}},    color={255,128,0})}));
+          textColor={0,0,255})}));
 end Cuboid;

--- a/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
@@ -4,6 +4,7 @@ model GenericFluxTube
 
   extends BaseClasses.FixedShape;
   extends Modelica.Magnetic.FluxTubes.Icons.Reluctance;
+
   parameter SI.Length l=0.01 "Length in direction of flux"
     annotation(Dialog(group="Fixed geometry", groupImage=
       "modelica://Modelica/Resources/Images/Magnetic/FluxTubes/Shapes/GenericFluxTube.png"));

--- a/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
@@ -3,6 +3,7 @@ model HollowCylinderAxialFlux
   "(Hollow) cylinder with axial flux; fixed shape; linear or non-linear material characteristics"
 
   extends BaseClasses.FixedShape;
+  extends Modelica.Magnetic.FluxTubes.Icons.HollowCylinderAxialFlux;
 
   parameter SI.Length l=0.01 "Axial length (in direction of flux)"
     annotation (Dialog(group="Fixed geometry", groupImage=
@@ -27,32 +28,8 @@ Set the inner radius r_i=0 for modelling of a solid cylindric flux tube.
 </p>
 </html>"),
     Icon(graphics={
-        Ellipse(
-          extent={{-70,30},{-50,-30}},
-          lineColor={255,128,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Rectangle(
-          extent={{-60,30},{60,-30}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
         Text(
           extent={{-150,50},{150,90}},
           textString="%name",
-          textColor={0,0,255}),
-        Ellipse(
-          extent={{50,30},{70,-30}},
-          lineColor={255,128,0},
-          fillColor={215,215,215},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{56,10},{64,-10}},
-          lineColor={255,128,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Line(points={{-60,30},{60,30}}, color={255,128,0}),
-        Line(points={{-60,-30},{60,-30}}, color={255,128,0}),
-        Line(points={{-70,0},{-100,0}}, color={255,128,0}),
-        Line(points={{100,0},{60,0}},   color={255,128,0})}));
+          textColor={0,0,255})}));
 end HollowCylinderAxialFlux;

--- a/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
+++ b/Modelica/Magnetic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
@@ -3,6 +3,7 @@ model HollowCylinderRadialFlux
   "Hollow cylinder with radial flux; fixed shape; linear or non-linear material characteristics"
 
   extends BaseClasses.FixedShape;
+  extends Modelica.Magnetic.FluxTubes.Icons.HollowCylinderRadialFlux;
 
   parameter SI.Length l=0.01 "Width (orthogonal to flux direction)"
                                            annotation (Dialog(group=
@@ -32,46 +33,8 @@ For those flux tube sections of a magnetic device that have a nonlinear material
 </p>
 </html>"),
     Icon(graphics={
-        Ellipse(
-          extent={{-10,60},{10,-60}},
-          lineColor={255,128,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid,
-          origin={0,-30},
-          rotation=90),
         Text(
           extent={{-150,50},{150,90}},
           textString="%name",
-          textColor={0,0,255}),
-        Rectangle(
-          extent={{-60,30},{60,-30}},
-          lineColor={255,255,255},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-        Ellipse(
-          extent={{-10,60},{10,-60}},
-          lineColor={255,128,0},
-          fillColor={215,215,215},
-          fillPattern=FillPattern.Solid,
-          origin={0,30},
-          rotation=90),
-        Ellipse(
-          extent={{-6,30},{6,-30}},
-          lineColor={255,128,0},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid,
-          origin={0,30},
-          rotation=90),
-        Line(
-          points={{-2,-1.22465e-16},{60,0}},
-          color={255,128,0},
-          origin={60,-30},
-          rotation=90),
-        Line(
-          points={{-60,0},{-3.20085e-22,-1.95996e-38}},
-          color={255,128,0},
-          origin={-60,30},
-          rotation=90),
-        Line(points={{-60,0},{-100,0}}, color={255,128,0}),
-        Line(points={{100,0},{60,0}},   color={255,128,0})}));
+          textColor={0,0,255})}));
 end HollowCylinderRadialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/FixedShape.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/FixedShape.mo
@@ -33,13 +33,6 @@ equation
   annotation (Icon(coordinateSystem(
       preserveAspectRatio=false,
       extent={{-100,-100},{100,100}}), graphics={
-      Rectangle(
-          extent={{-70,30},{70,-30}},
-          lineColor={255,170,85},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-      Line(points={{-70,0},{-90,0}}, color={255,170,85}),
-      Line(points={{70,0},{90,0}}, color={255,170,85}),
       Text(
         extent={{-150,50},{150,90}},
         textString="%name",

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/Leakage.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/BaseClasses/Leakage.mo
@@ -2,6 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FluxTubes.BaseClasses;
 partial model Leakage "Base class for leakage flux tubes with position-independent permeance and hence no force generation; mu_r=1"
 
   extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;
 
   SI.Reluctance R_m "Magnetic reluctance";
   SI.Permeance G_m "Magnetic permeance";
@@ -13,13 +14,6 @@ equation
   annotation (Icon(coordinateSystem(
       preserveAspectRatio=false,
       extent={{-100,-100},{100,100}}), graphics={
-      Rectangle(
-          extent={{-70,30},{70,-30}},
-          lineColor={255,170,85},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-      Line(points={{-70,0},{-90,0}}, color={255,170,85}),
-      Line(points={{70,0},{90,0}}, color={255,170,85}),
       Text(
         extent={{-150,50},{150,90}},
         textString="%name",

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/ConstantPermeance.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/ConstantPermeance.mo
@@ -2,6 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FluxTubes.Basic;
 model ConstantPermeance "Constant permeance"
 
   extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;
 
   parameter SI.Permeance G_m=1 "Magnetic permeance";
 
@@ -11,12 +12,6 @@ equation
   annotation (Icon(coordinateSystem(
       preserveAspectRatio=false,
       extent={{-100,-100},{100,100}}), graphics={
-      Rectangle(
-          extent={{-70,30},{70,-30}},
-          lineColor={255,170,85},
-          fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),
-      Line(points={{-70,0},{-90,0}}, color={255,170,85}),
       Line(points={{70,0},{90,0}}, color={255,170,85}),
       Text(
         extent={{-150,50},{150,90}},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/ConstantReluctance.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Basic/ConstantReluctance.mo
@@ -2,6 +2,7 @@ within Modelica.Magnetic.QuasiStatic.FluxTubes.Basic;
 model ConstantReluctance "Constant reluctance"
 
   extends Interfaces.TwoPorts;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;
 
   parameter SI.Reluctance R_m=1 "Magnetic reluctance";
 
@@ -11,12 +12,6 @@ equation
   annotation (Icon(coordinateSystem(
       preserveAspectRatio=false,
       extent={{-100,-100},{100,100}}), graphics={
-      Rectangle(
-        extent={{-70,30},{70,-30}},
-        lineColor={255,170,85},
-        fillColor={255,255,255},
-        fillPattern=FillPattern.Solid),
-      Line(points={{-70,0},{-90,0}}, color={255,170,85}),
       Line(points={{70,0},{90,0}}, color={255,170,85}),
       Text(
         extent={{-150,50},{150,90}},

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Cuboid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Cuboid.mo
@@ -6,12 +6,12 @@ partial model Cuboid "Icon for cuboid"
           textString="%name",
           textColor={0,0,255}),
         Rectangle(
-          extent={{-68,20},{50,-40}},
+          extent={{-70,20},{50,-40}},
           lineColor={255,170,85},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
         Polygon(
-          points={{-68,20},{-48,40},{70,40},{50,20},{-68,20}},
+          points={{-70,20},{-50,40},{70,40},{50,20},{-70,20}},
           lineColor={255,170,85},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Cuboid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Cuboid.mo
@@ -6,20 +6,20 @@ partial model Cuboid "Icon for cuboid"
           textString="%name",
           textColor={0,0,255}),
         Rectangle(
-          extent={{-60,20},{40,-40}},
+          extent={{-68,20},{50,-40}},
           lineColor={255,170,85},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
         Polygon(
-          points={{-60,20},{-40,40},{60,40},{40,20},{-60,20}},
+          points={{-68,20},{-48,40},{70,40},{50,20},{-68,20}},
           lineColor={255,170,85},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid),
         Polygon(
-          points={{40,20},{60,40},{60,-20},{40,-40},{40,20}},
+          points={{50,20},{70,40},{70,-20},{50,-40},{50,20}},
           lineColor={255,170,85},
           fillColor={215,215,215},
           fillPattern=FillPattern.Solid),
-        Line(points={{-60,0},{-100,0}}, color={255,170,85}),
-        Line(points={{100,0},{50,0}},   color={255,170,85})}));
+        Line(points={{-70,0},{-100,0}}, color={255,170,85}),
+        Line(points={{100,0},{60,0}},   color={255,170,85})}));
 end Cuboid;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Cuboid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Cuboid.mo
@@ -1,0 +1,25 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Icons;
+partial model Cuboid "Icon for cuboid"
+  annotation (Icon(graphics={
+        Text(
+          extent={{-150,50},{150,90}},
+          textString="%name",
+          textColor={0,0,255}),
+        Rectangle(
+          extent={{-60,20},{40,-40}},
+          lineColor={255,170,85},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{-60,20},{-40,40},{60,40},{40,20},{-60,20}},
+          lineColor={255,170,85},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Polygon(
+          points={{40,20},{60,40},{60,-20},{40,-40},{40,20}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid),
+        Line(points={{-60,0},{-100,0}}, color={255,170,85}),
+        Line(points={{100,0},{50,0}},   color={255,170,85})}));
+end Cuboid;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/HollowCylinderAxialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/HollowCylinderAxialFlux.mo
@@ -1,0 +1,32 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Icons;
+partial model HollowCylinderAxialFlux "Icon for cylinder with axial flux"
+  annotation (Icon(graphics={
+        Ellipse(
+          extent={{-70,30},{-50,-30}},
+          lineColor={255,170,85},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Rectangle(
+          extent={{-60,30},{60,-30}},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None),
+        Text(
+          extent={{-150,50},{150,90}},
+          textString="%name",
+          textColor={0,0,255}),
+        Ellipse(
+          extent={{50,30},{70,-30}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid),
+        Ellipse(
+          extent={{56,10},{64,-10}},
+          lineColor={255,170,85},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Line(points={{-60,30},{60,30}}, color={255,170,85}),
+        Line(points={{-60,-30},{60,-30}}, color={255,170,85}),
+        Line(points={{-70,0},{-100,0}}, color={255,170,85}),
+        Line(points={{100,0},{60,0}},   color={255,170,85})}));
+end HollowCylinderAxialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/HollowCylinderRadialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/HollowCylinderRadialFlux.mo
@@ -1,0 +1,46 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Icons;
+partial model HollowCylinderRadialFlux "Icon for cylinder with radial flux"
+  annotation (Icon(graphics={
+        Ellipse(
+          extent={{-10,60},{10,-60}},
+          lineColor={255,170,85},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid,
+          origin={0,-30},
+          rotation=90),
+        Text(
+          extent={{-150,50},{150,90}},
+          textString="%name",
+          textColor={0,0,255}),
+        Rectangle(
+          extent={{-60,30},{60,-30}},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid,
+          pattern=LinePattern.None),
+        Ellipse(
+          extent={{-10,60},{10,-60}},
+          lineColor={255,170,85},
+          fillColor={215,215,215},
+          fillPattern=FillPattern.Solid,
+          origin={0,30},
+          rotation=90),
+        Ellipse(
+          extent={{-6,30},{6,-30}},
+          lineColor={255,170,85},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid,
+          origin={0,30},
+          rotation=90),
+        Line(
+          points={{-2,-1.22465e-16},{60,0}},
+          color={255,128,0},
+          origin={60,-30},
+          rotation=90),
+        Line(
+          points={{-60,0},{-3.20085e-22,-1.95996e-38}},
+          color={255,170,85},
+          origin={-60,30},
+          rotation=90),
+        Line(points={{-60,0},{-100,0}}, color={255,170,85}),
+        Line(points={{100,0},{60,0}},   color={255,170,85})}));
+end HollowCylinderRadialFlux;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Reluctance.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/Reluctance.mo
@@ -1,0 +1,16 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes.Icons;
+partial model Reluctance "Icon for reluctance / permeance components"
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
+        Line(points={{-70,0},{-100,0}}, color={255,170,85}),
+        Rectangle(
+          extent={{-70,30},{70,-30}},
+          lineColor={255,170,85},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid),
+        Line(points={{70,0},{100,0}}, color={255,170,85}),
+        Text(
+          extent={{-150,50},{150,90}},
+          textString="%name",
+          textColor={0,0,255})}), Diagram(coordinateSystem(
+          preserveAspectRatio=false)));
+end Reluctance;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/package.mo
@@ -1,0 +1,7 @@
+within Modelica.Magnetic.QuasiStatic.FluxTubes;
+package Icons "Icons for FluxTubes components"
+  extends Modelica.Icons.IconsPackage;
+
+
+
+end Icons;

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Icons/package.order
@@ -1,0 +1,4 @@
+Reluctance
+Cuboid
+HollowCylinderAxialFlux
+HollowCylinderRadialFlux

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Cuboid.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/Cuboid.mo
@@ -3,6 +3,7 @@ model Cuboid
 "Flux tube with rectangular cross-section; fixed shape; linear or non-linear material characteristics"
 
   extends BaseClasses.FixedShape;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Cuboid;
 
   parameter SI.Length l=0.01 "Length in direction of flux" annotation (
       Dialog(group="Fixed geometry", groupImage=

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/GenericFluxTube.mo
@@ -3,6 +3,7 @@ model GenericFluxTube
 "Flux tube with fixed cross-section and length; linear or non-linear material characteristics"
 
   extends BaseClasses.FixedShape;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.Reluctance;
 
   parameter SI.Length l=0.01 "Length in direction of flux"
     annotation(Dialog(group="Fixed geometry", groupImage=

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderAxialFlux.mo
@@ -3,6 +3,7 @@ model HollowCylinderAxialFlux
 "(Hollow) cylinder with axial flux; fixed shape; linear or non-linear material characteristics"
 
   extends BaseClasses.FixedShape;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.HollowCylinderAxialFlux;
 
   parameter SI.Length l=0.01 "Axial length (in direction of flux)"
     annotation (Dialog(group="Fixed geometry", groupImage=

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/Shapes/FixedShape/HollowCylinderRadialFlux.mo
@@ -3,6 +3,7 @@ model HollowCylinderRadialFlux
 "Hollow cylinder with radial flux; fixed shape; linear or non-linear material characteristics"
 
   extends BaseClasses.FixedShape;
+  extends Modelica.Magnetic.QuasiStatic.FluxTubes.Icons.HollowCylinderRadialFlux;
 
   parameter SI.Length l=0.01 "Width (orthogonal to flux direction)"
                                            annotation (Dialog(group=

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/package.mo
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/package.mo
@@ -6,6 +6,7 @@ package FluxTubes "Library for modelling of quasi-static electromagnetic devices
   import Modelica.Constants.mu_0;
 
   extends Modelica.Icons.Package;
+
   annotation (Documentation(info="<html>
 <p>
 This library is intended to provide models for the investigation of

--- a/Modelica/Magnetic/QuasiStatic/FluxTubes/package.order
+++ b/Modelica/Magnetic/QuasiStatic/FluxTubes/package.order
@@ -6,3 +6,4 @@ Sensors
 Sources
 Interfaces
 BaseClasses
+Icons


### PR DESCRIPTION
This PR includes the following changes:

- Strictly use the new icons of `Magnetic.FluxTubes.Icons` in all components 
- Use the same icon scheme as in `Magnetic.FluxTubes` to distinguish different types of reluctances
- Strictly use the new icons of `Magnetic.QuasiStatic.FluxTubes.Icons` in all components 